### PR TITLE
Adds callbacks for the Menu statement

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1421,11 +1421,21 @@ class Menu(Node):
                 choices.append((label, condition, i))
                 next_node(block[0])
 
-        if narration:
-            renpy.exports.say(None, "\n".join(narration), interact=False)
+        auto_choice = None
+        if renpy.config.menu_choice_before_callback:
+            auto_choice = renpy.config.menu_choice_before_callback(choices, self.name)
 
-        say_menu_with(self.with_, renpy.game.interface.set_transition)
-        choice = renpy.exports.menu(choices, self.set)
+        if auto_choice is None:
+            if narration:
+                renpy.exports.say(None, "\n".join(narration), interact=False)
+
+            say_menu_with(self.with_, renpy.game.interface.set_transition)
+            choice = renpy.exports.menu(choices, self.set)
+        else:
+            choice = auto_choice
+
+        if renpy.config.menu_choice_after_callback and choice is not None:
+            renpy.config.menu_choice_after_callback(choice, self.name)
 
         if choice is not None:
             next_node(self.items[choice][2][0])

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -323,6 +323,14 @@ missing_image_callback = None
 # Called to filter text in the say and menu statements.
 say_menu_text_filter = None
 
+# Called to provide automatic choices for menus
+# type: ([(label:String, visible:String, index:Int)], NodeName) -> None | Int
+menu_choice_before_callback = None
+
+# Called to notify of a menu choice
+# type: ([(label:String, visible:String, index:Int)], NodeName) -> None
+menu_choice_after_callback = None
+
 # Used to replace one label with another.
 label_overrides = { }
 


### PR DESCRIPTION
These allow one to execute code before a menu is displayed to the
player (and potentially choose one of the menu options automatically),
and execute code after the player has picked a menu choice.

This change was made just to support Cute Demon Crashers! replay
feature, and isn't intended to be merged back in the Ren'Py main
branch. Although menu callbacks would probably be a nice thing.

Two new configurations have been added to support this change:

 -  `renpy.config.menu_choice_before_callback` is a function that takes in a
    list of menu choices, and the name of the node (which uniquely
    identifies it in the game), and can either return None, or an Int. If an
    Int is returned, it's assumed to be the index of the choice that should
    be automatically selected for the player.

 -  `renpy.config.menu_choice_after_callback` is a function that takes in
    the option the user has selected (an Int representing the index of the
    choice), and the name of the Node.